### PR TITLE
Only clixon server depends on args

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install pytest
           pip install -r requirements.txt
+      - name: Create folder
+        run: |
+          mkdir -p /usr/local/share/clixon/controller/modules/
       - name: Test with pytest
         run: |
           pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,22 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v3
-
-    - name: Install packages
-      run: sudo apt install -y python3-pip
-    - name: Clone PyAPI
-      run: (git clone https://github.com/clicon/clixon-pyapi.git && cd clixon-pyapi && pip3 install -r requirements.txt)
-    - name: Run tests
-      run: (cd clixon-pyapi && pytest)
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          architecture: 'x64'
+          cache: 'pip'
+            #- name: Install dependencies
+            #  # Are we using wheel?
+            #  run: python -m pip install --upgrade pip setuptools wheel
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+          pip install -r requirements.txt
+      - name: Test with pytest
+        run: |
+          pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           pip install -r requirements.txt
       - name: Create folder
         run: |
-          mkdir -p /usr/local/share/clixon/controller/modules/
+          sudo mkdir -p /usr/local/share/clixon/controller/modules/
       - name: Test with pytest
         run: |
           pytest

--- a/clixon/args.py
+++ b/clixon/args.py
@@ -59,7 +59,7 @@ def __parse_config_file(configfile: str) -> tuple:
 global_args = {}
 
 
-def parse_args(cli_args: Optional = None) -> tuple:
+def parse_args(cli_args: Optional[list] = None) -> tuple:
     """
     Parse command line arguments.
 

--- a/clixon/args.py
+++ b/clixon/args.py
@@ -5,7 +5,6 @@ import sys
 from typing import Optional
 
 import clixon.parser as parser
-from clixon.log import get_log_factory
 
 
 def __kill(pidfile: str) -> None:
@@ -133,20 +132,6 @@ def parse_args(cli_args: Optional = None) -> tuple:
             args.pp,
             args.log,
             args.debug)
-
-
-def get_logger():
-    """
-    Get logger.
-    :return: Logger
-    """
-
-    log = get_arg("log")
-    debug = get_arg("debug")
-
-    logger = get_log_factory(log, debug)
-
-    return logger
 
 
 def get_arg(opt: str):

--- a/clixon/args.py
+++ b/clixon/args.py
@@ -76,7 +76,7 @@ def parse_args(cli_args: Optional[list] = None) -> tuple:
     parser = argparse.ArgumentParser(description="clixon PyAPI")
     parser.add_argument("-f", "--configfile",
                         help="Clixon controller configuration file")
-    parser.add_argument("-m", "--modulepaths", action="append",
+    parser.add_argument("-m", "--modulepaths", action="append", default=[],
                         help="Modules path")
     parser.add_argument("-e", "--modulefilter", default="",
                         help="Comma separated list of modules to exclude")
@@ -101,14 +101,6 @@ def parse_args(cli_args: Optional[list] = None) -> tuple:
         __kill(args.pidfile)
         sys.exit(0)
 
-    if args.modulepaths is None:
-        args.modulepaths = [default_mpath]
-    args.modulepaths = list(set(args.modulepaths))
-
-    if not all(map(os.path.exists, args.modulepaths)):
-        print(f"Module path {args.modulepaths} contains non-existing paths")
-        sys.exit(0)
-
     if args.configfile is not None and not os.path.exists(args.configfile):
         print(f"Configuration file {args.configfile} does not exist")
         sys.exit(0)
@@ -128,6 +120,14 @@ def parse_args(cli_args: Optional[list] = None) -> tuple:
 
         args.modulefilter = modulefilter
         args.pidfile = pidfile
+
+    if len(args.modulepaths) == 0:
+        args.modulepaths = [default_mpath]
+    args.modulepaths = list(set(args.modulepaths))
+
+    if not all(map(os.path.exists, args.modulepaths)):
+        print(f"Module path {args.modulepaths} contains non-existing paths")
+        sys.exit(0)
 
     # Save args in global scope for get_args function
     global_args = vars(args)

--- a/clixon/client.py
+++ b/clixon/client.py
@@ -17,7 +17,7 @@ from clixon.parser import parse_string
 from clixon.sock import read, send, create_socket
 from clixon.event import RPCEventHandler
 
-logger = get_logger()
+logger = get_logger(__name__)
 events = RPCEventHandler()
 
 

--- a/clixon/client.py
+++ b/clixon/client.py
@@ -5,7 +5,7 @@ import time
 import traceback
 from typing import Optional
 import struct
-from clixon.args import get_logger
+from clixon.log import get_logger
 from clixon.modules import run_modules
 from clixon.netconf import (
     RPCTypes,

--- a/clixon/client.py
+++ b/clixon/client.py
@@ -1,11 +1,13 @@
-from socket import socket
+from logging import getLogger
 import re
+from socket import socket
+import struct
 import sys
 import time
 import traceback
 from typing import Optional
-import struct
-from clixon.log import get_logger
+
+from clixon.event import RPCEventHandler
 from clixon.modules import run_modules
 from clixon.netconf import (
     RPCTypes,
@@ -15,9 +17,9 @@ from clixon.netconf import (
 )
 from clixon.parser import parse_string
 from clixon.sock import read, send, create_socket
-from clixon.event import RPCEventHandler
 
-logger = get_logger(__name__)
+
+logger = getLogger(__name__)
 events = RPCEventHandler()
 
 

--- a/clixon/clixon.py
+++ b/clixon/clixon.py
@@ -1,23 +1,24 @@
+from logging import getLogger
 import os
 from typing import Optional
 
 from clixon.args import get_arg
-from clixon.log import get_logger
-from clixon.sock import read, send, create_socket
-from clixon.parser import parse_string
 from clixon.netconf import (
     rpc_commit,
     rpc_config_get,
     rpc_config_set,
-    rpc_push,
+    rpc_error_get,
     rpc_pull,
-    rpc_subscription_create,
-    rpc_error_get
+    rpc_push,
+    rpc_subscription_create
 )
+from clixon.parser import parse_string
+from clixon.sock import create_socket, read, send
+
 
 sockpath = get_arg("sockpath")
 pp = get_arg("pp")
-logger = get_logger(__name__)
+logger = getLogger(__name__)
 default_sockpath = "/usr/local/var/run/controller.sock"
 
 

--- a/clixon/clixon.py
+++ b/clixon/clixon.py
@@ -1,7 +1,8 @@
 import os
 from typing import Optional
 
-from clixon.args import get_arg, get_logger
+from clixon.args import get_arg
+from clixon.log import get_logger
 from clixon.sock import read, send, create_socket
 from clixon.parser import parse_string
 from clixon.netconf import (

--- a/clixon/clixon.py
+++ b/clixon/clixon.py
@@ -17,7 +17,7 @@ from clixon.netconf import (
 
 sockpath = get_arg("sockpath")
 pp = get_arg("pp")
-logger = get_logger()
+logger = get_logger(__name__)
 default_sockpath = "/usr/local/var/run/controller.sock"
 
 

--- a/clixon/event.py
+++ b/clixon/event.py
@@ -1,8 +1,9 @@
-from typing import Callable as function, Optional
+from logging import getLogger
 from fnmatch import fnmatch
-from clixon.log import get_logger
+from typing import Callable as function, Optional
 
-logger = get_logger(__name__)
+
+logger = getLogger(__name__)
 
 
 class RPCEventHandler():

--- a/clixon/event.py
+++ b/clixon/event.py
@@ -2,7 +2,7 @@ from typing import Callable as function, Optional
 from fnmatch import fnmatch
 from clixon.log import get_logger
 
-logger = get_logger()
+logger = get_logger(__name__)
 
 
 class RPCEventHandler():

--- a/clixon/event.py
+++ b/clixon/event.py
@@ -1,7 +1,6 @@
 from typing import Callable as function, Optional
 from fnmatch import fnmatch
-from clixon.args import get_logger
-from enum import Enum
+from clixon.log import get_logger
 
 logger = get_logger()
 

--- a/clixon/log.py
+++ b/clixon/log.py
@@ -37,8 +37,3 @@ def init_root_logger(
         logger.setLevel(logging.INFO)
 
     return logger
-
-
-def get_logger(name: str):
-    "Get child of root logger."
-    return logging.getLogger("root." + name)

--- a/clixon/log.py
+++ b/clixon/log.py
@@ -4,23 +4,27 @@ from typing import Optional
 import os
 
 
-def get_log_factory(output: Optional[str] = "s",
-                    debug: Optional[bool] = False) -> logging.Logger:
+logger_name = "pyserver"
+
+
+def init_logger(output: Optional[str] = "s",
+                debug: Optional[bool] = False) -> logging.Logger:
     """
-    Get logger for the application.
+    Initialize logger for the application.
+
     :param output: Output type. "s" for syslog anything else for stdout
     :param debug: Debug mode.
     :return: Logger
     """
 
-    logger = logging.getLogger('pyserver')
+    logger = logging.getLogger(logger_name)
     if not logger.handlers:
         formatter = logging.Formatter(
-            '[%(asctime)s] %(levelname)s in %(module)s: %(message)s')
+            "[%(asctime)s] %(levelname)s in %(module)s: %(message)s")
 
         if output == "s":
             if os.path.exists("/dev/log"):
-                handler = SysLogHandler(address='/dev/log')
+                handler = SysLogHandler(address="/dev/log")
             else:
                 handler = SysLogHandler()
         else:
@@ -35,3 +39,8 @@ def get_log_factory(output: Optional[str] = "s",
         logger.setLevel(logging.INFO)
 
     return logger
+
+
+def get_logger():
+    "Fetch logger with name logger_name"
+    return logging.getLogger(logger_name)

--- a/clixon/log.py
+++ b/clixon/log.py
@@ -4,20 +4,18 @@ from typing import Optional
 import os
 
 
-logger_name = "pyserver"
-
-
-def init_logger(output: Optional[str] = "s",
-                debug: Optional[bool] = False) -> logging.Logger:
+def init_root_logger(
+        output: Optional[str] = "s",
+        debug: Optional[bool] = False) -> logging.Logger:
     """
-    Initialize logger for the application.
+    Initialize root logger for the application.
 
     :param output: Output type. "s" for syslog anything else for stdout
     :param debug: Debug mode.
     :return: Logger
     """
 
-    logger = logging.getLogger(logger_name)
+    logger = logging.getLogger()
     if not logger.handlers:
         formatter = logging.Formatter(
             "[%(asctime)s] %(levelname)s in %(module)s: %(message)s")
@@ -41,6 +39,6 @@ def init_logger(output: Optional[str] = "s",
     return logger
 
 
-def get_logger():
-    "Fetch logger with name logger_name"
-    return logging.getLogger(logger_name)
+def get_logger(name: str):
+    "Get child of root logger."
+    return logging.getLogger("root." + name)

--- a/clixon/modules.py
+++ b/clixon/modules.py
@@ -8,7 +8,7 @@ from clixon.args import get_arg
 from clixon.clixon import Clixon
 from clixon.log import get_logger
 
-logger = get_logger()
+logger = get_logger(__name__)
 sockpath = get_arg("sockpath")
 
 

--- a/clixon/modules.py
+++ b/clixon/modules.py
@@ -4,8 +4,9 @@ import sys
 import traceback
 from typing import List, Optional
 
-from clixon.args import get_logger, get_arg
+from clixon.args import get_arg
 from clixon.clixon import Clixon
+from clixon.log import get_logger
 
 logger = get_logger()
 sockpath = get_arg("sockpath")

--- a/clixon/modules.py
+++ b/clixon/modules.py
@@ -1,4 +1,5 @@
 import importlib.util
+from logging import getLogger
 import os
 import sys
 import traceback
@@ -6,9 +7,9 @@ from typing import List, Optional
 
 from clixon.args import get_arg
 from clixon.clixon import Clixon
-from clixon.log import get_logger
 
-logger = get_logger(__name__)
+
+logger = getLogger(__name__)
 sockpath = get_arg("sockpath")
 
 

--- a/clixon/modules.py
+++ b/clixon/modules.py
@@ -4,11 +4,11 @@ import sys
 import traceback
 from typing import List, Optional
 
-from clixon.args import get_logger, get_sockpath
+from clixon.args import get_logger, get_arg
 from clixon.clixon import Clixon
 
 logger = get_logger()
-sockpath = get_sockpath()
+sockpath = get_arg("sockpath")
 
 
 class ModuleError(Exception):

--- a/clixon/netconf.py
+++ b/clixon/netconf.py
@@ -4,7 +4,7 @@ from xml.sax._exceptions import SAXParseException
 
 from clixon.element import Element
 from clixon.parser import parse_string
-from clixon.args import get_logger
+from clixon.log import get_logger
 
 import sys
 

--- a/clixon/netconf.py
+++ b/clixon/netconf.py
@@ -1,14 +1,14 @@
 from enum import Enum
+from logging import getLogger
+import sys
 from typing import Optional
 from xml.sax._exceptions import SAXParseException
 
 from clixon.element import Element
 from clixon.parser import parse_string
-from clixon.log import get_logger
 
-import sys
 
-logger = get_logger(__name__)
+logger = getLogger(__name__)
 
 
 class RPCTypes(Enum):

--- a/clixon/netconf.py
+++ b/clixon/netconf.py
@@ -8,7 +8,7 @@ from clixon.log import get_logger
 
 import sys
 
-logger = get_logger()
+logger = get_logger(__name__)
 
 
 class RPCTypes(Enum):

--- a/clixon/sock.py
+++ b/clixon/sock.py
@@ -7,7 +7,7 @@ from clixon.element import Element
 from clixon.parser import dump_string
 
 
-logger = get_logger()
+logger = get_logger(__name__)
 hdrlen = 8
 
 

--- a/clixon/sock.py
+++ b/clixon/sock.py
@@ -1,10 +1,9 @@
 import socket
-from clixon.args import get_logger
+from clixon.log import get_logger
 from typing import Optional
 import select
 import struct
 from clixon.element import Element
-from clixon.netconf import rpc_error_get
 from clixon.parser import dump_string
 
 

--- a/clixon/sock.py
+++ b/clixon/sock.py
@@ -1,13 +1,14 @@
-import socket
-from clixon.log import get_logger
-from typing import Optional
+from logging import getLogger
 import select
+import socket
 import struct
+from typing import Optional
+
 from clixon.element import Element
 from clixon.parser import dump_string
 
 
-logger = get_logger(__name__)
+logger = getLogger(__name__)
 hdrlen = 8
 
 

--- a/clixon_server.py
+++ b/clixon_server.py
@@ -8,8 +8,16 @@ from clixon.args import parse_args, get_logger
 from clixon.client import readloop
 from clixon.modules import load_modules
 
-(sockpath, mpath, mfilter, pidfile, foreground,
- pp, _, _) = parse_args(sys.argv[1:])
+(
+    sockpath,
+    mpath,
+    mfilter,
+    pidfile,
+    foreground,
+    pp,
+    _,
+    _
+) = parse_args(sys.argv[1:])
 
 logger = get_logger()
 lockfd = None

--- a/clixon_server.py
+++ b/clixon_server.py
@@ -5,7 +5,7 @@ import sys
 from daemonize import Daemonize
 
 from clixon.args import parse_args
-from clixon.log import init_logger
+from clixon.log import init_root_logger
 from clixon.client import readloop
 from clixon.modules import load_modules
 
@@ -20,7 +20,7 @@ from clixon.modules import load_modules
     debug
 ) = parse_args(sys.argv[1:])
 
-logger = init_logger(log, debug)
+logger = init_root_logger(log, debug)
 lockfd = None
 
 

--- a/clixon_server.py
+++ b/clixon_server.py
@@ -4,7 +4,8 @@ import sys
 
 from daemonize import Daemonize
 
-from clixon.args import parse_args, get_logger
+from clixon.args import parse_args
+from clixon.log import init_logger
 from clixon.client import readloop
 from clixon.modules import load_modules
 
@@ -15,11 +16,11 @@ from clixon.modules import load_modules
     pidfile,
     foreground,
     pp,
-    _,
-    _
+    log,
+    debug
 ) = parse_args(sys.argv[1:])
 
-logger = get_logger()
+logger = init_logger(log, debug)
 lockfd = None
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pytest==7.4.3
 pytest-cov==4.1.0
 tomli==2.0.1
 xmltodict==0.13.0
+pytest-mock

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -53,6 +53,61 @@ def test_get_sockpath():
     assert get_arg("sockpath") == '/test/socket'
 
 
+@patch("sys.argv", ["test", "-P"])
+def test_get_prettyprint():
+    """
+    Test that the pretty print is returned correctly.
+    """
+
+    parse_args()
+    assert get_arg("pp") is True
+
+
+@patch("sys.argv", ["test"])
+def test_modulepath_fallback():
+    """
+    Test that fallback module path is added when no modulepath is provided.
+    """
+
+    fallback_mpath = "/usr/local/share/clixon/controller/modules"
+    parse_args()
+    mpaths = get_arg("modulepaths")
+    assert mpaths == [fallback_mpath]
+    assert len(mpaths) == 1
+
+
+@patch("sys.argv", ["test", "-m", "/tmp"])
+def test_modulepath_argument():
+    """
+    Test that
+    - argument is added,
+    - fallback module path is not added.
+    """
+
+    parse_args()
+    mpaths = get_arg("modulepaths")
+    assert mpaths == ["/tmp"]
+    assert len(mpaths) == 1
+
+
+@patch("sys.argv", ["test", "-f", "dummy_config_file"])
+def test_modulepath_configfile(mocker):
+    """
+    Test that
+    - configfile modulpath is added,
+    - fallback module path is not added.
+    """
+    mock_path_exist = mocker.patch("os.path.exists")
+    mock_path_exist.return_value = True
+    mock_conf_parser = mocker.patch("clixon.args.__parse_config_file")
+    mock_conf_parser.return_value = ("a", ["/tmp/conf_file_mpath"], "b", "c")
+
+    parse_args()
+    mpaths = get_arg("modulepaths")
+    assert mpaths == ["/tmp/conf_file_mpath"]
+    assert len(mpaths) == 1
+
+
 @patch('sys.exit')
 @patch('builtins.print')
 def test_usage(mock_print, mock_exit):

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 from clixon.args import parse_args, get_arg
 
 
-
 def test_parse_args():
     """
     Test that the arguments are parsed correctly.

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -34,7 +34,7 @@ def test_parse_args():
 
         assert sockpath == "/test/socket"
         for m_path in modulepaths:
-            assert m_path == "/tmp"
+            assert m_path == tmp_file
         assert modulefilter == ""
         assert pidfile == "/test/pidfile"
         assert foreground is True

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -1,4 +1,4 @@
-import tempfile
+import os
 from unittest.mock import patch
 
 from clixon.args import parse_args, get_arg
@@ -9,32 +9,32 @@ def test_parse_args():
     """
     Test that the arguments are parsed correctly.
     """
-    with tempfile.TemporaryDirectory(dir=".") as tmp_dir:
-        (
-            sockpath,
-            modulepaths,
-            modulefilter,
-            pidfile,
-            foreground,
-            pp,
-            log,
-            debug
-        ) = parse_args(
-            ["-s", "/test/socket",
-             "-p", "/test/pidfile",
-             "-m", tmp_dir,
-             "-l" "o",
-             "-F", "-d", "-P"])
-        assert sockpath == "/test/socket"
-        for m_path in modulepaths:
-            assert m_path in ["/usr/local/share/clixon/controller/modules/",
-                              tmp_dir]
-        assert modulefilter == ""
-        assert pidfile == "/test/pidfile"
-        assert foreground is True
-        assert pp is True
-        assert log == "o"
-        assert debug is True
+    current_path = os.environ["PWD"]
+    (
+        sockpath,
+        modulepaths,
+        modulefilter,
+        pidfile,
+        foreground,
+        pp,
+        log,
+        debug
+    ) = parse_args(
+        ["-s", "/test/socket",
+         "-p", "/test/pidfile",
+         "-m", current_path,
+         "-l" "o",
+         "-F", "-d", "-P"])
+    assert sockpath == "/test/socket"
+    for m_path in modulepaths:
+        assert m_path in ["/usr/local/share/clixon/controller/modules/",
+                          current_path]
+    assert modulefilter == ""
+    assert pidfile == "/test/pidfile"
+    assert foreground is True
+    assert pp is True
+    assert log == "o"
+    assert debug is True
 
 
 @patch("sys.argv", ["test", "-s", "/test/socket"])

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 from unittest.mock import patch
 
 from clixon.args import parse_args, get_arg
@@ -8,32 +9,32 @@ def test_parse_args():
     """
     Test that the arguments are parsed correctly.
     """
-    current_path = os.environ["PWD"]
-    (
-        sockpath,
-        modulepaths,
-        modulefilter,
-        pidfile,
-        foreground,
-        pp,
-        log,
-        debug
-    ) = parse_args(
-        ["-s", "/test/socket",
-         "-p", "/test/pidfile",
-         "-m", current_path,
-         "-l" "o",
-         "-F", "-d", "-P"])
-    assert sockpath == "/test/socket"
-    for m_path in modulepaths:
-        assert m_path in ["/usr/local/share/clixon/controller/modules/",
-                          current_path]
-    assert modulefilter == ""
-    assert pidfile == "/test/pidfile"
-    assert foreground is True
-    assert pp is True
-    assert log == "o"
-    assert debug is True
+    with tempfile.TemporaryDirectory() as tmp_file:
+        (
+            sockpath,
+            modulepaths,
+            modulefilter,
+            pidfile,
+            foreground,
+            pp,
+            log,
+            debug
+        ) = parse_args(
+            ["-s", "/test/socket",
+             "-p", "/test/pidfile",
+             "-m", tmp_file,
+             "-l" "o",
+             "-F", "-d", "-P"])
+        assert sockpath == "/test/socket"
+        for m_path in modulepaths:
+            assert m_path in ["/usr/local/share/clixon/controller/modules/",
+                              tmp_file]
+        assert modulefilter == ""
+        assert pidfile == "/test/pidfile"
+        assert foreground is True
+        assert pp is True
+        assert log == "o"
+        assert debug is True
 
 
 @patch("sys.argv", ["test", "-s", "/test/socket"])

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -1,10 +1,13 @@
+import tempfile
 from unittest.mock import patch
+
 from clixon.args import parse_args, get_arg
 
+tmp_dir = tempfile.TemporaryDirectory()
 
-@patch("sys.argv", [
-    "test", "-s", "/test/socket", "-p", "/test/pidfile", "-m", "./modules/",
-    "-l" "o", "-F", "-d", "-P"])
+
+@patch("sys.argv", ["test", "-s", "/test/socket", "-p", "/test/pidfile", "-m",
+                    tmp_dir.name, "-l" "o", "-F", "-d", "-P"])
 def test_parse_args():
     """
     Test that the arguments are parsed correctly.
@@ -23,7 +26,7 @@ def test_parse_args():
     assert sockpath == "/test/socket"
     for m_path in modulepaths:
         assert m_path in ["/usr/local/share/clixon/controller/modules/",
-                          "./modules/"]
+                          tmp_dir.name]
     assert modulefilter == ""
     assert pidfile == "/test/pidfile"
     assert foreground is True

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -1,5 +1,5 @@
 from unittest.mock import patch
-from clixon.args import parse_args, get_logger, get_arg
+from clixon.args import parse_args, get_arg
 
 
 @patch("sys.argv", [
@@ -30,17 +30,6 @@ def test_parse_args():
     assert pp is True
     assert log == "o"
     assert debug is True
-
-
-@patch("sys.argv", ["test"])
-def test_get_logger():
-    """
-    Test that the logger is created correctly.
-    """
-
-    logger = get_logger()
-
-    assert logger is not None
 
 
 @patch("sys.argv", ["test", "-s", "/test/socket"])

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -9,7 +9,7 @@ def test_parse_args():
     """
     Test that the arguments are parsed correctly.
     """
-    with tempfile.TemporaryDirectory() as tmp_dir:
+    with tempfile.TemporaryDirectory(dir=".") as tmp_dir:
         (
             sockpath,
             modulepaths,
@@ -43,6 +43,7 @@ def test_get_sockpath():
     Test that the socket path is returned correctly.
     """
 
+    parse_args()
     assert get_arg("sockpath") == '/test/socket'
 
 

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -1,5 +1,5 @@
 from unittest.mock import patch
-from clixon.args import parse_args, get_logger, get_sockpath, get_prettyprint
+from clixon.args import parse_args, get_logger, get_arg
 
 
 @patch("sys.argv", [
@@ -49,16 +49,7 @@ def test_get_sockpath():
     Test that the socket path is returned correctly.
     """
 
-    assert get_sockpath() == '/test/socket'
-
-
-@patch("sys.argv", ["test", "-P"])
-def test_get_prettyprint():
-    """
-    Test that the prettyprint flag is returned correctly.
-    """
-
-    assert get_prettyprint() is True
+    assert get_arg("sockpath") == '/test/socket'
 
 
 @patch('sys.exit')

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -3,36 +3,38 @@ from unittest.mock import patch
 
 from clixon.args import parse_args, get_arg
 
-tmp_dir = tempfile.TemporaryDirectory()
 
 
-@patch("sys.argv", ["test", "-s", "/test/socket", "-p", "/test/pidfile", "-m",
-                    tmp_dir.name, "-l" "o", "-F", "-d", "-P"])
 def test_parse_args():
     """
     Test that the arguments are parsed correctly.
     """
-    (
-        sockpath,
-        modulepaths,
-        modulefilter,
-        pidfile,
-        foreground,
-        pp,
-        log,
-        debug
-    ) = parse_args()
-
-    assert sockpath == "/test/socket"
-    for m_path in modulepaths:
-        assert m_path in ["/usr/local/share/clixon/controller/modules/",
-                          tmp_dir.name]
-    assert modulefilter == ""
-    assert pidfile == "/test/pidfile"
-    assert foreground is True
-    assert pp is True
-    assert log == "o"
-    assert debug is True
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        (
+            sockpath,
+            modulepaths,
+            modulefilter,
+            pidfile,
+            foreground,
+            pp,
+            log,
+            debug
+        ) = parse_args(
+            ["-s", "/test/socket",
+             "-p", "/test/pidfile",
+             "-m", tmp_dir,
+             "-l" "o",
+             "-F", "-d", "-P"])
+        assert sockpath == "/test/socket"
+        for m_path in modulepaths:
+            assert m_path in ["/usr/local/share/clixon/controller/modules/",
+                              tmp_dir]
+        assert modulefilter == ""
+        assert pidfile == "/test/pidfile"
+        assert foreground is True
+        assert pp is True
+        assert log == "o"
+        assert debug is True
 
 
 @patch("sys.argv", ["test", "-s", "/test/socket"])

--- a/tests/test_configfile.py
+++ b/tests/test_configfile.py
@@ -1,5 +1,5 @@
 import pytest
-from clixon.args import __parse_config
+from clixon.args import __parse_config_file
 from clixon.parser import parse_file
 
 config_xml = """
@@ -125,7 +125,7 @@ def test_args_parse_config():
     with open("/tmp/config.xml", "w") as fd:
         fd.write(config_xml)
 
-    sockpath, modulepath, modulefilter, pidfile = __parse_config(
+    sockpath, modulepath, modulefilter, pidfile = __parse_config_file(
         "/tmp/config.xml")
 
     assert sockpath == "/usr/local/var/controller.sock"

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,10 +1,10 @@
-from clixon.log import init_root_logger, get_logger
+from clixon.log import init_root_logger
 import logging
 
 
 def test_log():
     """
-    Test the root logger.
+    Test init_root_logger.
     """
 
     logger = init_root_logger()
@@ -21,11 +21,11 @@ def test_get_logger(caplog):
     """
     _ = init_root_logger(output="stdout", debug=True)
 
-    logger = get_logger("module_name")
+    logger = logging.getLogger("module_name")
 
     assert logger is not None
     assert logger.parent is not None
-    assert logger.name == "root.module_name"
+    assert logger.name == "module_name"
 
     assert logger.debug("info test") is None
     assert "info test" in caplog.text
@@ -49,7 +49,7 @@ def test_log_stdout(caplog):
     assert logger.info("info test") is None
     assert "info test" in caplog.text
 
-    assert get_logger("child_module").level == logging.NOTSET
+    assert logging.getLogger("child_module").level == logging.NOTSET
 
 
 def test_log_debug(caplog):
@@ -70,4 +70,4 @@ def test_log_debug(caplog):
     assert logger.debug("debug test") is None
     assert "debug test" in caplog.text
 
-    assert get_logger("child_module").level == logging.NOTSET
+    assert logging.getLogger("child_module").level == logging.NOTSET

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,4 +1,4 @@
-from clixon.log import get_log_factory
+from clixon.log import init_logger, get_logger
 import logging
 
 
@@ -7,11 +7,22 @@ def test_log():
     Test the default log factory.
     """
 
-    logger = get_log_factory()
+    logger = init_logger()
 
     assert logger.name == "pyserver"
     assert logger.level == logging.INFO
     assert logger.hasHandlers() is True
+
+
+def test_get_logger():
+    """
+    Test that the logger is fetched correctly.
+    """
+
+    logger = get_logger()
+
+    assert logger is not None
+    assert logger.name == "pyserver"
 
 
 def test_log_stdout(caplog):
@@ -19,7 +30,7 @@ def test_log_stdout(caplog):
     Test the default log factory with output to stdout.
     """
 
-    logger = get_log_factory(output="stdout")
+    logger = init_logger(output="stdout")
 
     assert logger.name == "pyserver"
     assert logger.level == logging.INFO
@@ -31,13 +42,15 @@ def test_log_stdout(caplog):
     assert logger.info("info test") is None
     assert "info test" in caplog.text
 
+    assert get_logger().level == logging.INFO
+
 
 def test_log_debug(caplog):
     """
     Test the default log factory with debug enabled.
     """
 
-    logger = get_log_factory(debug=True)
+    logger = init_logger(debug=True)
 
     assert logger.name == "pyserver"
     assert logger.level == logging.DEBUG
@@ -48,3 +61,5 @@ def test_log_debug(caplog):
 
     assert logger.debug("debug test") is None
     assert "debug test" in caplog.text
+
+    assert get_logger().level == logging.DEBUG

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,28 +1,34 @@
-from clixon.log import init_logger, get_logger
+from clixon.log import init_root_logger, get_logger
 import logging
 
 
 def test_log():
     """
-    Test the default log factory.
+    Test the root logger.
     """
 
-    logger = init_logger()
+    logger = init_root_logger()
 
-    assert logger.name == "pyserver"
+    assert logger.name == "root"
     assert logger.level == logging.INFO
+    assert logger.parent is None
     assert logger.hasHandlers() is True
 
 
-def test_get_logger():
+def test_get_logger(caplog):
     """
     Test that the logger is fetched correctly.
     """
+    _ = init_root_logger(output="stdout", debug=True)
 
-    logger = get_logger()
+    logger = get_logger("module_name")
 
     assert logger is not None
-    assert logger.name == "pyserver"
+    assert logger.parent is not None
+    assert logger.name == "root.module_name"
+
+    assert logger.debug("info test") is None
+    assert "info test" in caplog.text
 
 
 def test_log_stdout(caplog):
@@ -30,10 +36,11 @@ def test_log_stdout(caplog):
     Test the default log factory with output to stdout.
     """
 
-    logger = init_logger(output="stdout")
+    logger = init_root_logger(output="stdout")
 
-    assert logger.name == "pyserver"
+    assert logger.name == "root"
     assert logger.level == logging.INFO
+    assert logger.parent is None
     assert logger.hasHandlers() is True
 
     assert logger.debug("debug test") is None
@@ -42,7 +49,7 @@ def test_log_stdout(caplog):
     assert logger.info("info test") is None
     assert "info test" in caplog.text
 
-    assert get_logger().level == logging.INFO
+    assert get_logger("child_module").level == logging.NOTSET
 
 
 def test_log_debug(caplog):
@@ -50,10 +57,11 @@ def test_log_debug(caplog):
     Test the default log factory with debug enabled.
     """
 
-    logger = init_logger(debug=True)
+    logger = init_root_logger(debug=True)
 
-    assert logger.name == "pyserver"
+    assert logger.name == "root"
     assert logger.level == logging.DEBUG
+    assert logger.parent is None
     assert logger.hasHandlers() is True
 
     assert logger.info("info test") is None
@@ -62,4 +70,4 @@ def test_log_debug(caplog):
     assert logger.debug("debug test") is None
     assert "debug test" in caplog.text
 
-    assert get_logger().level == logging.DEBUG
+    assert get_logger("child_module").level == logging.NOTSET


### PR DESCRIPTION
- Only call `parse_args` once, from the CLI app.
- Use `logging.logger` hierarchy instead of saving global args. By setting root logger config in __main__, modules using `getLogger(__name__)` will get children of the root logger.