### PR TITLE
Remove appending class proprties to property cache.  Correct element …

### DIFF
--- a/clixon/element.py
+++ b/clixon/element.py
@@ -493,10 +493,8 @@ class Element(object):
         matching_children = [x for x in self._children if x._name == key]
         if matching_children:
             if len(matching_children) == 1:
-                self.__dict__[key] = matching_children[0]
                 return matching_children[0]
             else:
-                self.__dict__[key] = matching_children
                 return matching_children
         else:
             raise AttributeError("'%s' has no attribute '%s'" % (self._name, key))

--- a/clixon/helpers.py
+++ b/clixon/helpers.py
@@ -291,7 +291,7 @@ def get_path(root: Element, path: str) -> Optional[Element]:
         node = node.replace("-", "_")
 
         try:
-            if not new_root:
+            if new_root is None:
                 new_root = getattr(root, node)
             else:
                 new_root = getattr(new_root, node)


### PR DESCRIPTION
…instance logic in helpers/get_path

Element class __getattr__ method appends data to class property cache, however those properties aren't always valid, such as if a single instance of a key is later converted to a list. This results in a mangled tree where the data is still in the tree, but attempts to access it now reference the wrong objects.

In get_path, there is a check while descending the Element class tree where a check is performed to see if a matching element is instantiated or not, however, a __bool__ override in the Element class returns False when in the case of get_path, the result should be true. Changing the logic to not use the boolean from the class, and instead just check if the new path has been stored or is still the default value of None.