### PR TITLE
Element class bugfixes

### DIFF
--- a/clixon/element.py
+++ b/clixon/element.py
@@ -9,7 +9,7 @@ class Element(object):
     def __init__(
         self,
         name: Optional[str] = "root",
-        attributes: Optional[dict] = {},
+        attributes: Optional[dict] = None,
         cdata: Optional[str] = "",
         data: Optional[str] = "",
         parent: Optional[object] = None,
@@ -30,7 +30,11 @@ class Element(object):
 
         """
 
-        self.attributes = attributes
+        if attributes:
+            self.attributes = attributes.copy()
+        else:
+            self.attributes = dict()
+
         self._children = []
         self._is_root = False
 
@@ -153,6 +157,7 @@ class Element(object):
 
         """
 
+        element._parent = self
         self._children.append(element)
 
     def delete(
@@ -520,6 +525,8 @@ class Element(object):
         return self.cdata.strip()
 
     def __repr__(self) -> str:
+        if self.cdata.strip() == '':
+            return self._name
         return self.cdata.strip()
 
     def __bool__(self) -> bool:


### PR DESCRIPTION
Bugfix for Element Class:

1. If get_attributes append and set_attributes are used, all class instances get updated to new attributes, rather than the specific instance. This is due to the instance being created with a attribute reference to the static type empty class '{}'.

2. Set the parent of a child when using add method in Element.add(). 

3. Update to __repr__() to use the object's name for a string representation if the cdata is empty.  This makes debugging much easier, as an object that contains children instead of data can now return its own name instead of an empty string, making the tree read similarly to the XML.