### PR TITLE
Element class creator tagging method.

### DIFF
--- a/clixon/element.py
+++ b/clixon/element.py
@@ -493,10 +493,8 @@ class Element(object):
         matching_children = [x for x in self._children if x._name == key]
         if matching_children:
             if len(matching_children) == 1:
-                self.__dict__[key] = matching_children[0]
                 return matching_children[0]
             else:
-                self.__dict__[key] = matching_children
                 return matching_children
         else:
             raise AttributeError("'%s' has no attribute '%s'" % (self._name, key))

--- a/clixon/element.py
+++ b/clixon/element.py
@@ -9,7 +9,7 @@ class Element(object):
     def __init__(
         self,
         name: Optional[str] = "root",
-        attributes: Optional[dict] = {},
+        attributes: Optional[dict] = None,
         cdata: Optional[str] = "",
         data: Optional[str] = "",
         parent: Optional[object] = None,
@@ -30,7 +30,11 @@ class Element(object):
 
         """
 
-        self.attributes = attributes
+        if attributes:
+            self.attributes = attributes.copy()
+        else:
+            self.attributes = dict()
+
         self._children = []
         self._is_root = False
 
@@ -153,6 +157,7 @@ class Element(object):
 
         """
 
+        element._parent = self
         self._children.append(element)
 
     def delete(
@@ -520,6 +525,8 @@ class Element(object):
         return self.cdata.strip()
 
     def __repr__(self) -> str:
+        if self.cdata.strip() == '':
+            return self._name
         return self.cdata.strip()
 
     def __bool__(self) -> bool:

--- a/clixon/element.py
+++ b/clixon/element.py
@@ -10,7 +10,7 @@ class Element(object):
     def __init__(
         self,
         name: Optional[str] = "root",
-        attributes: Optional[dict] = None,
+        attributes: Optional[dict] = {},
         cdata: Optional[str] = "",
         data: Optional[str] = "",
         parent: Optional[object] = None,
@@ -31,11 +31,7 @@ class Element(object):
 
         """
 
-        if attributes:
-            self.attributes = attributes.copy()
-        else:
-            self.attributes = dict()
-
+        self.attributes = attributes
         self._children = []
         self._is_root = False
 
@@ -158,7 +154,6 @@ class Element(object):
 
         """
 
-        element._parent = self
         self._children.append(element)
 
     def delete(
@@ -550,8 +545,6 @@ class Element(object):
         return self.cdata.strip()
 
     def __repr__(self) -> str:
-        if self.cdata.strip() == '':
-            return self._name
         return self.cdata.strip()
 
     def __bool__(self) -> bool:

--- a/clixon/element.py
+++ b/clixon/element.py
@@ -6,6 +6,7 @@ import yaml
 
 
 class Element(object):
+    _creatortag = None
     def __init__(
         self,
         name: Optional[str] = "root",
@@ -470,6 +471,30 @@ class Element(object):
         """
 
         return self.get_elements(name=name, recursive=True)
+
+    def set_creator(self,creator: str) -> None:
+        """
+        Set the creator tag to all class instances
+        :creator string: Valid XPath creator tag
+        :return: None
+        :rtype: None
+
+        """
+        Element._creatortag = creator
+
+    def tag_creator(self) -> None:
+        """
+        Apply creator tag to Element
+        :return: self
+        :rtype: Element
+        """
+        if Element._creatortag:
+            attribs = self.get_attributes()
+            attribs['cl:creator'] = Element._creatortag
+            self.set_attributes(attribs)
+            return self
+        else:
+            raise("Creator tag not defined")
 
     def __getitem__(self, key: str) -> Optional[dict]:
         """

--- a/clixon/helpers.py
+++ b/clixon/helpers.py
@@ -291,7 +291,7 @@ def get_path(root: Element, path: str) -> Optional[Element]:
         node = node.replace("-", "_")
 
         try:
-            if not new_root:
+            if new_root is None:
                 new_root = getattr(root, node)
             else:
                 new_root = getattr(new_root, node)


### PR DESCRIPTION
I think this PR is best explained by an example.  I do not think the code is good enough to actually accept the PR at this time, but I want feedback on whether this kind of modification is reasonable or could be accepted if polished.

```
SERVICE = "service-name"

@rpc()
def setup(root, log, **kwargs):
    rootcfg = root.get_root()
    rootcfg.set_creator(f"{SERVICE}[service-name='{kwargs['instance']}']")
    rootcfg = functionA(rootcfg)
    return root
    
    
# Main only gets called when debugging from shell
def main():
    clx = Clixon(source="running",target="candidate")
    rootcfg = clx.get_root()
    rootcfg.set_creator(f"{SERVICE}[service-name='mesh1']")
    functionA(rootcfg)
	
	
def functionA(config):
	config_branch = get_path(config,"config_branch")
	functionB(config_branch)

def functionB(config_branch):
	new_key = config_branch.create('new-key')
	
	# At this point multiple-function calls in, we don't have the context of the instance anymore, 
	# so it either requres passing it through every function call, defining global vars, 
	# or just using a class variable to store that context so it can be retrieved by a new method.
	new_key.tag_creator()

if __name__ == "__main__":
    main()
```