### PR TITLE
Feature show devices and rollback

### DIFF
--- a/clixon/clixon.py
+++ b/clixon/clixon.py
@@ -21,6 +21,8 @@ from clixon.netconf import (
     rpc_subscription_create,
     rpc_unlock,
     rpc_transactions_get,
+    rpc_devices_get,
+    rpc_discard_changes,
 )
 from clixon.parser import parse_string
 from clixon.sock import create_socket, read, send
@@ -618,6 +620,25 @@ class Clixon:
 
         return data
 
+    def rollback(self) -> None:
+        """
+        Rollback / discard candidate.
+
+        :param target: Target
+        :type target: str
+        :return: None
+        :rtype: None
+
+        """
+
+        logger.info(f"Rollback, discard_changes")
+
+        rpc = rpc_discard_changes(user=self.__user)
+        send(self.__socket, rpc, pp)
+        data = read(self.__socket, pp)
+
+        self.__handle_errors(data)
+
     def show_transactions(self, tid: Optional[int] = None) -> str:
         rpc = rpc_transactions_get(tid=tid, user=self.__user)
 
@@ -627,6 +648,15 @@ class Clixon:
 
         data = read(self.__socket, pp)
 
+        return data
+
+    def show_devices(self) -> str:
+        """
+        Get device names, connection states, timestamps, and log messages.
+        """
+        rpc = rpc_devices_get(user=self.__user)
+        send(self.__socket, rpc, pp)
+        data = read(self.__socket, pp)
         return data
 
 

--- a/clixon/netconf.py
+++ b/clixon/netconf.py
@@ -627,7 +627,7 @@ def rpc_devices_get(user: Optional[str] = None) -> Element:
         "xmlns:nc": "urn:ietf:params:xml:ns:netconf:base:1.0",
         "cl:username": user,
         "xmlns:cl": "http://clicon.org/lib",
-        "message-id": "45",
+        "message-id": "42",
     }
 
     filter_attributes = {

--- a/tests/test_netconf.py
+++ b/tests/test_netconf.py
@@ -433,3 +433,23 @@ def test_rpc_transactions_get():
     assert netconf.rpc_transactions_get(tid=123).dumps() == xmlstr1
     assert netconf.rpc_transactions_get(user="test123").dumps() == xmlstr2
     assert netconf.rpc_transactions_get(tid=123, user="test123").dumps() == xmlstr3
+
+
+def test_rpc_discard_changes():
+    """
+    Test the rpc_discard_changes function.
+    """
+
+    xmlstr0 = f"""<rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" cl:username="{user}" xmlns:cl="http://clicon.org/lib" message-id="42"><discard-changes/></rpc>"""
+
+    assert netconf.rpc_discard_changes().dumps() == xmlstr0
+
+
+def test_rpc_devices_get():
+    """
+    Test the rpc_devices_get function.
+    """
+
+    xmlstr0 = f"""<rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" cl:username="{user}" xmlns:cl="http://clicon.org/lib" message-id="42"><get cl:content="all" xmlns:cl="http://clicon.org/lib"><nc:filter nc:type="xpath" nc:select="co:devices/co:device/co:name | co:devices/co:device/co:conn-state | co:devices/co:device/co:conn-state-timestamp | co:devices/co:device/co:logmsg" xmlns:co="http://clicon.org/controller"/><with-defaults xmlns="urn:ietf:params:xml:ns:yang:ietf-netconf-with-defaults">explicit</with-defaults></get></rpc>"""
+
+    assert netconf.rpc_devices_get().dumps() == xmlstr0


### PR DESCRIPTION
Added RPCs for rpc_show_devices and rpc_discard_changes and methods rollback() and show_devices. This is the same as the CLI commands 'rollback' and 'show connections'.